### PR TITLE
fix: unblock macOS clang build (3 declaration conflicts)

### DIFF
--- a/include/core/literal.h
+++ b/include/core/literal.h
@@ -56,8 +56,6 @@ struct ch_literal_runtime {
     constexpr ch_literal_runtime(int64_t v) noexcept
         : ch_literal_runtime(static_cast<uint64_t>(v), compute_width(v)) {}
 
-    constexpr ch_literal_runtime(unsigned long long v) noexcept
-        : ch_literal_runtime(static_cast<uint64_t>(v), compute_width(v)) {}
 
     constexpr ch_literal_runtime(int v) noexcept
         : ch_literal_runtime(v, compute_width(v)) {}

--- a/include/core/logic_buffer.h
+++ b/include/core/logic_buffer.h
@@ -43,13 +43,13 @@ template <typename T> struct logic_buffer {
     // === 类型转换增强 ===
 
     // 通用类型转换
-    template <unsigned NewWidth> auto as() const;
+
 
     // 符号扩展
-    template <unsigned NewWidth> auto sext() const;
+
 
     // 零扩展
-    template <unsigned NewWidth> auto zext() const;
+
 
     // === 查询操作 ===
 

--- a/include/lnode/logic_buffer.tpp
+++ b/include/lnode/logic_buffer.tpp
@@ -55,31 +55,6 @@ template <typename T> auto logic_buffer<T>::lsb() const {
 }
 
 // 类型转换增强实现
-template <typename T>
-template <unsigned NewWidth>
-auto logic_buffer<T>::as() const {
-    if constexpr (NewWidth > T::width) {
-        return zero_extend(*static_cast<const T *>(this), NewWidth);
-    } else if constexpr (NewWidth < T::width) {
-        return bits(*static_cast<const T *>(this), NewWidth - 1, 0);
-    } else {
-        return *static_cast<const T *>(this);
-    }
-}
-
-template <typename T>
-template <unsigned NewWidth>
-auto logic_buffer<T>::sext() const {
-    static_assert(NewWidth >= T::width, "New width must be >= current width");
-    return sign_extend(*static_cast<const T *>(this), NewWidth);
-}
-
-template <typename T>
-template <unsigned NewWidth>
-auto logic_buffer<T>::zext() const {
-    static_assert(NewWidth >= T::width, "New width must be >= current width");
-    return zero_extend(*static_cast<const T *>(this), NewWidth);
-}
 
 // 查询操作实现
 template <typename T> bool logic_buffer<T>::is_zero() const {


### PR DESCRIPTION
## Summary

Two mechanical deletions that unblock macOS/arm64 in CI:

1. **`include/core/literal.h:59-60`** — duplicate `(unsigned long long v)` ctor (== `uint64_t` on macOS arm64; redeclaration error)
2. **`include/core/logic_buffer.h` + `include/lnode/logic_buffer.tpp`** — 3 dead member functions (`as`, `sext`, `zext`) that conflict with the free functions in `ch::core` namespace, causing clang's dependent-base lookup errors at `include/core/uint.h:48` and `:79`

## Risk assessment

- Bug #1 (`literal.h`): Only 2 call sites pass ULL (`src/lnode/bool.cpp:15`, `tests/test_literal.cpp:954`). Both resolve to the 2-arg ctor. On macOS via exact match, on Linux via standard conversion (no warning).
- Bug #2 (`logic_buffer`): The 3 member functions are **dead code** — `grep -rE '\.zext<|\.sext<|\.as<'` returns zero hits excluding third_party/verilator. They exist solely to conflict with the free functions.

## Verification

- `grep -c 'unsigned long long' include/core/literal.h` returns 0 (was 1)
- `grep -E 'auto (as|sext|zext)\(\)' include/core/logic_buffer.h` returns 0
- `grep -E 'logic_buffer<T>::(as|sext|zext)\(\)' include/lnode/logic_buffer.tpp` returns 0
- `grep -rE '\.zext<|\.sext<|\.as<' --include='*.cpp' --include='*.h' --include='*.tpp' | grep -v third_party/verilator` returns 0
- Build succeeds on Linux gcc with `-DCH_JIT_ENABLE=OFF -DBUILD_VERILATOR=OFF`
- 133/133 ctest tests pass (8 JIT tests excluded by CH_JIT_ENABLE=OFF, validated in nightly-verilator job)

## Related

- Part of the macOS unblock effort: see `.omo/plans/macos-source-bug-fixes.md`
- Sister PR #18 (operators.h e59c0f4 regression restore) is the first part
- Followups (separate PR): CI re-enable (PR-4)